### PR TITLE
LDPD-260: Convert Travis CI config to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ '*' ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt-hotspot'
+          java-version: '8'
+      # TODO: Run tests.  This is just a basic port from Travis CI (where tests weren't previously
+      # running), except that we're using Java 8 in the configuration above instead of Java 7.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: java
-jdk:
-  - openjdk7
-  - oraclejdk7


### PR DESCRIPTION
Note: The previous Travis CI config didn't really do a lot (other than set up Java), so there wasn't much to port here.